### PR TITLE
Removed case sensitivity from reader column names.  Based on best ans…

### DIFF
--- a/Snowflake.Data/Core/SFResultSetMetaData.cs
+++ b/Snowflake.Data/Core/SFResultSetMetaData.cs
@@ -35,7 +35,7 @@ namespace Snowflake.Data.Core
         /// <summary>
         ///     This map is used to cache column name to column index. Index is 0-based.
         /// </summary>
-        private Dictionary<string, int> columnNameToIndexCache = new Dictionary<string, int>();
+        private Dictionary<string, int> columnNameToIndexCache = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
         internal SFResultSetMetaData(QueryExecResponseData queryExecResponseData)
         {
@@ -95,7 +95,7 @@ namespace Snowflake.Data.Core
                 int indexCounter = 0;
                 foreach (ExecResponseRowType rowType in rowTypes)
                 {
-                    if (String.Compare(rowType.name, targetColumnName, false ) == 0 )
+                    if (String.Compare(rowType.name, targetColumnName, StringComparison.OrdinalIgnoreCase ) == 0 )
                     {
                         logger.Info($"Found colun name {targetColumnName} under index {indexCounter}");
                         columnNameToIndexCache[targetColumnName] = indexCounter;


### PR DESCRIPTION
…wer here.

"Table and column names are already case-insensitive, unless you are querying them as values within information_schema views. " https://community.snowflake.com/s/question/0D50Z00009SDHEoSAP/is-there-case-insensitivity-for-table-name-or-column-names